### PR TITLE
refactor: 가게 생성 임시데이터 사용으로 변경

### DIFF
--- a/src/main/java/com/example/jomajomadelivery/auth/web/config/SecurityConfig.java
+++ b/src/main/java/com/example/jomajomadelivery/auth/web/config/SecurityConfig.java
@@ -22,7 +22,7 @@ public class SecurityConfig {
         return http
                 .csrf(AbstractHttpConfigurer::disable) // CSRF 보호 비활성화 (CSRF:악의적인 사이트에서 사용자의 인증된 세션을 악용해 요청을 보내는 공격)
                 .authorizeHttpRequests(auth ->
-                        auth.requestMatchers("/", "/login", "/css/**").permitAll() // 해당 요청을 인증 없이 허용
+                        auth.requestMatchers("/**").permitAll() // 해당 요청을 인증 없이 허용
                                 .anyRequest().authenticated()
                 )
 //                .formLogin(AbstractHttpConfigurer::disable) // 기본적으로 제공하는 로그인 페이지 비활성화

--- a/src/main/java/com/example/jomajomadelivery/auth/web/config/SecurityConfig.java
+++ b/src/main/java/com/example/jomajomadelivery/auth/web/config/SecurityConfig.java
@@ -22,7 +22,7 @@ public class SecurityConfig {
         return http
                 .csrf(AbstractHttpConfigurer::disable) // CSRF 보호 비활성화 (CSRF:악의적인 사이트에서 사용자의 인증된 세션을 악용해 요청을 보내는 공격)
                 .authorizeHttpRequests(auth ->
-                        auth.requestMatchers("/**").permitAll() // 해당 요청을 인증 없이 허용
+                        auth.requestMatchers("/", "/login", "/css/**").permitAll() // 해당 요청을 인증 없이 허용
                                 .anyRequest().authenticated()
                 )
 //                .formLogin(AbstractHttpConfigurer::disable) // 기본적으로 제공하는 로그인 페이지 비활성화

--- a/src/main/java/com/example/jomajomadelivery/store/controller/StoreController.java
+++ b/src/main/java/com/example/jomajomadelivery/store/controller/StoreController.java
@@ -34,6 +34,12 @@ public class StoreController {
         return new ResponseEntity<>(storeList, HttpStatus.OK);
     }
 
+    @GetMapping("/{store_id}")
+    public ResponseEntity<StoreResponseDto> findById(@PathVariable Long store_id){
+        StoreResponseDto responseDto = storeService.findById(store_id);
+        return new ResponseEntity<>(responseDto, HttpStatus.OK);
+    }
+
     @PatchMapping("/{store_id}")
     public ResponseEntity<StoreResponseDto> updateStore(@PathVariable Long store_id,@RequestBody UpdateStoreRequestDto dto){
         StoreResponseDto responseDto = storeService.updateStore(store_id,dto);

--- a/src/main/java/com/example/jomajomadelivery/store/controller/StoreController.java
+++ b/src/main/java/com/example/jomajomadelivery/store/controller/StoreController.java
@@ -22,6 +22,8 @@ public class StoreController {
 
 
     private final StoreService storeService;
+    // view를 위해 "/new"사용. GET메소드 사용시 폼 으로 이동.
+
     @PostMapping("/new")
     public ResponseEntity<Void> addStore(@Valid @RequestBody StoreRequestDto dto){
         storeService.addStore(dto);

--- a/src/main/java/com/example/jomajomadelivery/store/controller/StoreController.java
+++ b/src/main/java/com/example/jomajomadelivery/store/controller/StoreController.java
@@ -1,6 +1,7 @@
 package com.example.jomajomadelivery.store.controller;
 
 import com.example.jomajomadelivery.store.dto.request.StoreRequestDto;
+import com.example.jomajomadelivery.store.dto.request.UpdateStoreRequestDto;
 import com.example.jomajomadelivery.store.dto.response.StoreResponseDto;
 import com.example.jomajomadelivery.store.service.StoreService;
 import jakarta.validation.Valid;
@@ -10,10 +11,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.*;
 
 @Controller
 @RequiredArgsConstructor
@@ -34,5 +32,11 @@ public class StoreController {
     public ResponseEntity<Page<StoreResponseDto>> findAllStore(Pageable pageable){
         Page<StoreResponseDto> storeList = storeService.findAllStore(pageable);
         return new ResponseEntity<>(storeList, HttpStatus.OK);
+    }
+
+    @PatchMapping("/{store_id}")
+    public ResponseEntity<StoreResponseDto> updateStore(@PathVariable Long store_id,@RequestBody UpdateStoreRequestDto dto){
+        StoreResponseDto responseDto = storeService.updateStore(store_id,dto);
+        return new ResponseEntity<>(responseDto, HttpStatus.OK);
     }
 }

--- a/src/main/java/com/example/jomajomadelivery/store/controller/StoreController.java
+++ b/src/main/java/com/example/jomajomadelivery/store/controller/StoreController.java
@@ -23,26 +23,33 @@ public class StoreController {
     // view를 위해 "/new"사용. GET메소드 사용시 폼 으로 이동.
 
     @PostMapping("/new")
-    public ResponseEntity<Void> addStore(@Valid @RequestBody StoreRequestDto dto){
+    public ResponseEntity<Void> addStore(@Valid @RequestBody StoreRequestDto dto) {
         storeService.addStore(dto);
         return ResponseEntity.ok().build();
     }
 
     @GetMapping
-    public ResponseEntity<Page<StoreResponseDto>> findAllStore(Pageable pageable){
+    public ResponseEntity<Page<StoreResponseDto>> findAllStore(Pageable pageable) {
         Page<StoreResponseDto> storeList = storeService.findAllStore(pageable);
         return new ResponseEntity<>(storeList, HttpStatus.OK);
     }
 
     @GetMapping("/{store_id}")
-    public ResponseEntity<StoreResponseDto> findById(@PathVariable Long store_id){
+    public ResponseEntity<StoreResponseDto> findById(@PathVariable Long store_id) {
         StoreResponseDto responseDto = storeService.findById(store_id);
         return new ResponseEntity<>(responseDto, HttpStatus.OK);
     }
 
     @PatchMapping("/{store_id}")
-    public ResponseEntity<StoreResponseDto> updateStore(@PathVariable Long store_id,@RequestBody UpdateStoreRequestDto dto){
-        StoreResponseDto responseDto = storeService.updateStore(store_id,dto);
+    public ResponseEntity<StoreResponseDto> updateStore(@PathVariable Long store_id,
+                                                        @RequestBody UpdateStoreRequestDto dto) {
+        StoreResponseDto responseDto = storeService.updateStore(store_id, dto);
         return new ResponseEntity<>(responseDto, HttpStatus.OK);
+    }
+
+    @DeleteMapping("/{store_id}")
+    public ResponseEntity<Void> shutDownStore(@PathVariable Long store_id) {
+        storeService.shutDownStore(store_id);
+        return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/example/jomajomadelivery/store/dto/request/UpdateStoreRequestDto.java
+++ b/src/main/java/com/example/jomajomadelivery/store/dto/request/UpdateStoreRequestDto.java
@@ -1,0 +1,13 @@
+package com.example.jomajomadelivery.store.dto.request;
+
+import java.time.LocalTime;
+
+public record UpdateStoreRequestDto(
+        String description,
+        String imgPath,
+        LocalTime openTime,
+        LocalTime closeTime,
+        int minOrderPrice,
+        int deliveryPrice
+) {
+}

--- a/src/main/java/com/example/jomajomadelivery/store/entity/Store.java
+++ b/src/main/java/com/example/jomajomadelivery/store/entity/Store.java
@@ -2,6 +2,7 @@ package com.example.jomajomadelivery.store.entity;
 
 import com.example.jomajomadelivery.common.BaseEntity;
 import com.example.jomajomadelivery.store.dto.request.StoreRequestDto;
+import com.example.jomajomadelivery.store.dto.request.UpdateStoreRequestDto;
 import com.example.jomajomadelivery.user.entity.User;
 import jakarta.persistence.*;
 import lombok.*;
@@ -81,6 +82,16 @@ public class Store extends BaseEntity {
                 .rating(0.0)
                 .isDeleted(false)
                 .build();
+    }
+
+    public Store updateStore(UpdateStoreRequestDto dto){
+        this.description=dto.description();
+        this.imgPath=dto.imgPath();
+        this.openTime=dto.openTime();
+        this.closeTime=dto.closeTime();
+        this.minOrderPrice=dto.minOrderPrice();
+        this.deliveryPrice=dto.deliveryPrice();
+        return this;
     }
 
 }

--- a/src/main/java/com/example/jomajomadelivery/store/entity/Store.java
+++ b/src/main/java/com/example/jomajomadelivery/store/entity/Store.java
@@ -94,4 +94,8 @@ public class Store extends BaseEntity {
         return this;
     }
 
+    public void shutDownStore(){
+        this.isDeleted=true;
+    }
+
 }

--- a/src/main/java/com/example/jomajomadelivery/store/entity/Store.java
+++ b/src/main/java/com/example/jomajomadelivery/store/entity/Store.java
@@ -50,7 +50,7 @@ public class Store extends BaseEntity {
     private LocalTime closeTime;
 
     @Column(name = "rating", nullable = false)
-    private Double rating=0.0;
+    private Double rating;
 
     @Column(name = "min_order_price")
     private int minOrderPrice;
@@ -59,7 +59,7 @@ public class Store extends BaseEntity {
     private int deliveryPrice;
 
     @Column(name = "favorite_count", nullable = false)
-    private Long favoriteCount=0L;
+    private Long favoriteCount;
 
     @Column(name = "is_deleted", nullable = false)
     private Boolean isDeleted;
@@ -71,11 +71,15 @@ public class Store extends BaseEntity {
                 .name(dto.name())
                 .description(dto.description())
                 .address(dto.address())
+                .phoneNumber(dto.phoneNumber())
                 .imgPath(dto.imgPath())
                 .openTime(dto.openTime())
                 .closeTime(dto.closeTime())
                 .minOrderPrice(dto.minOrderPrice())
                 .deliveryPrice(dto.deliveryPrice())
+                .favoriteCount(0L)
+                .rating(0.0)
+                .isDeleted(false)
                 .build();
     }
 

--- a/src/main/java/com/example/jomajomadelivery/store/service/StoreService.java
+++ b/src/main/java/com/example/jomajomadelivery/store/service/StoreService.java
@@ -1,6 +1,7 @@
 package com.example.jomajomadelivery.store.service;
 
 import com.example.jomajomadelivery.store.dto.request.StoreRequestDto;
+import com.example.jomajomadelivery.store.dto.request.UpdateStoreRequestDto;
 import com.example.jomajomadelivery.store.dto.response.StoreResponseDto;
 import com.example.jomajomadelivery.store.entity.Store;
 import com.example.jomajomadelivery.store.repository.StoreRepository;
@@ -11,7 +12,10 @@ import com.example.jomajomadelivery.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
 
 @Service
 @RequiredArgsConstructor
@@ -34,5 +38,14 @@ public class StoreService {
         // Todo: 빈 배열일 경우 에러 던지깅
 
         return storeList.map(StoreResponseDto::toDTO);
+    }
+
+    @Transactional
+    public StoreResponseDto updateStore(Long storeId, UpdateStoreRequestDto dto) {
+        Store store = storeRepository.findById(storeId)
+                .orElseThrow(()->new ResponseStatusException(HttpStatus.NOT_FOUND,"없슈"));
+        store.updateStore(dto);
+        return StoreResponseDto.toDTO(store);
+
     }
 }

--- a/src/main/java/com/example/jomajomadelivery/store/service/StoreService.java
+++ b/src/main/java/com/example/jomajomadelivery/store/service/StoreService.java
@@ -4,6 +4,10 @@ import com.example.jomajomadelivery.store.dto.request.StoreRequestDto;
 import com.example.jomajomadelivery.store.dto.response.StoreResponseDto;
 import com.example.jomajomadelivery.store.entity.Store;
 import com.example.jomajomadelivery.store.repository.StoreRepository;
+import com.example.jomajomadelivery.user.dto.request.SignUpUserDto;
+import com.example.jomajomadelivery.user.entity.Role;
+import com.example.jomajomadelivery.user.entity.User;
+import com.example.jomajomadelivery.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -13,11 +17,15 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class StoreService {
     private final StoreRepository storeRepository;
+    private final UserRepository userRepository;
     public void addStore(StoreRequestDto dto) {
-//        User user = new User(1L,"aa","aa","dd", Role.SELLER,"dd","dd",false);
-//        Store store =Store.addStore(user,dto);
+
+        SignUpUserDto signUpUserDto = new SignUpUserDto("aa","aa","dd", Role.SELLER,"dd","dd","","","","","","");
+        User user = User.createUser(signUpUserDto);
+        userRepository.save(user);
+        Store store =Store.addStore(user,dto);
 //        //Todo dto에서 세부 주소를 따로 받고 store 엔티티 수정해야함.
-//        storeRepository.save(store);
+        storeRepository.save(store);
     }
 
     //Todo: 요청에따라 필터링

--- a/src/main/java/com/example/jomajomadelivery/store/service/StoreService.java
+++ b/src/main/java/com/example/jomajomadelivery/store/service/StoreService.java
@@ -48,4 +48,10 @@ public class StoreService {
         return StoreResponseDto.toDTO(store);
 
     }
+
+    public StoreResponseDto findById(Long storeId) {
+        Store store = storeRepository.findById(storeId)
+                .orElseThrow(()->new ResponseStatusException(HttpStatus.NOT_FOUND,"없슈"));
+        return StoreResponseDto.toDTO(store);
+    }
 }

--- a/src/main/java/com/example/jomajomadelivery/store/service/StoreService.java
+++ b/src/main/java/com/example/jomajomadelivery/store/service/StoreService.java
@@ -54,4 +54,10 @@ public class StoreService {
                 .orElseThrow(()->new ResponseStatusException(HttpStatus.NOT_FOUND,"없슈"));
         return StoreResponseDto.toDTO(store);
     }
+    @Transactional
+    public void shutDownStore(Long storeId) {
+        Store store = storeRepository.findById(storeId)
+                .orElseThrow(()->new ResponseStatusException(HttpStatus.NOT_FOUND,"없슈"));
+        store.shutDownStore();
+    }
 }

--- a/src/main/java/com/example/jomajomadelivery/user/entity/User.java
+++ b/src/main/java/com/example/jomajomadelivery/user/entity/User.java
@@ -49,6 +49,7 @@ public class User extends BaseEntity {
                 .role(dto.role())
                 .nickName(dto.nickname())
                 .phoneNumber(dto.phoneNumber())
+                .isDeleted(false)
                 .build();
     }
 }

--- a/src/main/resources/application-env.yml
+++ b/src/main/resources/application-env.yml
@@ -1,0 +1,21 @@
+spring:
+  datasource:
+    url: jdbc:mysql://localhost:3306/joma
+    username: root
+    password: 123456
+    driver-class-name: com.mysql.cj.jdbc.Driver
+
+  jpa:
+    hibernate:
+      ddl-auto: create
+    properties:
+      hibernate:
+        show_sql: true
+        format_sql: true
+        use_sql_comments: true
+        dialect: org.hibernate.dialect.MySQL8Dialect
+
+  security:
+    user:
+      name: admin
+      password: 123455

--- a/src/main/resources/templates/login.html
+++ b/src/main/resources/templates/login.html
@@ -10,7 +10,8 @@
 
 <!-- 네이버로 로그인 버튼 -->
 <a href="/oauth2/authorization/naver">
-    <img src="/images/naver_login.png" alt="Naver Login" />
+    <img width="223"
+         src="https://developers.naver.com/doc/review_201802/CK_bEFnWMeEBjXpQ5o8N_20180202_7aot50.png" />
 </a>
 
 </body>


### PR DESCRIPTION
## 🔘구현 기능
### 1.임시로user 생성하여 가게 생성되게끔 구현
### 2. 가게정보 수정 기능 구현(가게설명,이미지,오픈시간,마감시간,최소주문금액,배달팁)
### 3. 가게 단건조회 구현
### 4. 가게 폐업 로직 구현
 <br>

## 🔎 고민한 부분 

- 빌더 메소드? 부분에 모든 값을 넣어줘야 null이 안들어감. 첨에는 변수를 초기화했지만 빌더메소드에서 따로 건드리지 않으면 null이 들어가서 수정하게됨.
---  
- 수정 시 빌더패턴메소드로 했지만! 객체 수정이 안되어 JPA가 변경감지를 못했다!
그래서! 수정메소드를 만들어 (셋터너낌) 수정되게 구현하였다!
---
- 가게 폐업시 Setter쓸까했는데 쫌 그래서.. 필드가 하나여도! 엔티티 클래스에서 매소드만들어  isDeleted가 true가 되도록 구현
  <br>