### PR TITLE
refactor: 장바구니 추가 로직 도메인 분리

### DIFF
--- a/src/main/java/com/example/jomajomadelivery/auth/web/config/SecurityConfig.java
+++ b/src/main/java/com/example/jomajomadelivery/auth/web/config/SecurityConfig.java
@@ -22,7 +22,7 @@ public class SecurityConfig {
         return http
                 .csrf(AbstractHttpConfigurer::disable) // CSRF 보호 비활성화 (CSRF:악의적인 사이트에서 사용자의 인증된 세션을 악용해 요청을 보내는 공격)
                 .authorizeHttpRequests(auth ->
-                        auth.requestMatchers("/", "/login", "/css/**", "/images/**").permitAll() // 해당 요청을 인증 없이 허용
+                        auth.requestMatchers("/**").permitAll() // 해당 요청을 인증 없이 허용
                                 .anyRequest().authenticated()
                 )
                 .oauth2Login(auth ->

--- a/src/main/java/com/example/jomajomadelivery/auth/web/config/SecurityConfig.java
+++ b/src/main/java/com/example/jomajomadelivery/auth/web/config/SecurityConfig.java
@@ -22,7 +22,7 @@ public class SecurityConfig {
         return http
                 .csrf(AbstractHttpConfigurer::disable) // CSRF 보호 비활성화 (CSRF:악의적인 사이트에서 사용자의 인증된 세션을 악용해 요청을 보내는 공격)
                 .authorizeHttpRequests(auth ->
-                        auth.requestMatchers("/**").permitAll() // 해당 요청을 인증 없이 허용
+                        auth.requestMatchers("/", "/login", "/css/**", "/images/**").permitAll() // 해당 요청을 인증 없이 허용
                                 .anyRequest().authenticated()
                 )
                 .oauth2Login(auth ->

--- a/src/main/java/com/example/jomajomadelivery/cart/controller/CartController.java
+++ b/src/main/java/com/example/jomajomadelivery/cart/controller/CartController.java
@@ -1,10 +1,11 @@
 package com.example.jomajomadelivery.cart.controller;
 
 import com.example.jomajomadelivery.cart.dto.requestDto.AddCartRequestDto;
+import com.example.jomajomadelivery.cart.entity.Cart;
 import com.example.jomajomadelivery.cart.service.CartService;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -16,9 +17,13 @@ public class CartController {
     private final CartService cartService;
 
     @PostMapping
-    public ResponseEntity<Void> addCart(@RequestBody AddCartRequestDto dto){
-        cartService.addCart(dto);
-        return null;
+    public String addCart(@RequestBody AddCartRequestDto dto, Model model) {
+        Cart cart = cartService.addCart();
+        model.addAttribute("dto", dto);
+        model.addAttribute("cart", cart);
+        System.out.println("cart "+dto.menu_id());
+        System.out.println("cart "+dto.quantity());
+        return "forward:/items";
     }
 
 }

--- a/src/main/java/com/example/jomajomadelivery/cart/repository/CartRepository.java
+++ b/src/main/java/com/example/jomajomadelivery/cart/repository/CartRepository.java
@@ -9,4 +9,5 @@ import java.util.Optional;
 
 public interface CartRepository extends JpaRepository<Cart,Long> {
     Optional<Cart> findCartByUserAndStatus(User user, CartStatus status);
+    Optional<Cart> findByUser(User user);
 }

--- a/src/main/java/com/example/jomajomadelivery/cart/service/CartService.java
+++ b/src/main/java/com/example/jomajomadelivery/cart/service/CartService.java
@@ -1,13 +1,8 @@
 package com.example.jomajomadelivery.cart.service;
 
-import com.example.jomajomadelivery.cart.dto.requestDto.AddCartRequestDto;
 import com.example.jomajomadelivery.cart.entity.Cart;
 import com.example.jomajomadelivery.cart.entity.CartStatus;
 import com.example.jomajomadelivery.cart.repository.CartRepository;
-import com.example.jomajomadelivery.item.entity.Item;
-import com.example.jomajomadelivery.item.repository.ItmeRepositoy;
-import com.example.jomajomadelivery.menu.entity.Menu;
-import com.example.jomajomadelivery.menu.repository.MenuRepository;
 import com.example.jomajomadelivery.user.entity.User;
 import com.example.jomajomadelivery.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
@@ -19,18 +14,12 @@ public class CartService {
 
     private final UserRepository userRepository;
     private final CartRepository cartRepository;
-    private final MenuRepository menuRepository;
-    private final ItmeRepositoy itmeRepositoy;
 
-    public void addCart(AddCartRequestDto dto) {
+    public Cart addCart() {
         User user = userRepository.findById(1L).get();
         Cart cart = cartRepository.findCartByUserAndStatus(user, CartStatus.ORDERING).orElseGet(() ->
                 cartRepository.save(Cart.newCart(user))
         );
-        Menu menu = menuRepository.findById(dto.menu_id()).get();
-
-        Item item = Item.selectItme(cart,menu,dto.quantity());
-        itmeRepositoy.save(item);
-
+        return cart;
     }
 }

--- a/src/main/java/com/example/jomajomadelivery/item/controller/ItemController.java
+++ b/src/main/java/com/example/jomajomadelivery/item/controller/ItemController.java
@@ -29,9 +29,9 @@ public class ItemController {
         return new ResponseEntity<>(HttpStatus.OK);
     }
 
-    @GetMapping("/{cartId}")
-    public ResponseEntity<List<ItemResponseDto>> findAllItem(@PathVariable Long cartId) {
-        List<ItemResponseDto> itemList = itemService.findAllItem(cartId);
+    @GetMapping()
+    public ResponseEntity<List<ItemResponseDto>> findAllItem() {
+        List<ItemResponseDto> itemList = itemService.findAllItem();
         return new ResponseEntity<>(itemList, HttpStatus.OK);
     }
 }

--- a/src/main/java/com/example/jomajomadelivery/item/controller/ItemController.java
+++ b/src/main/java/com/example/jomajomadelivery/item/controller/ItemController.java
@@ -2,14 +2,15 @@ package com.example.jomajomadelivery.item.controller;
 
 import com.example.jomajomadelivery.cart.dto.requestDto.AddCartRequestDto;
 import com.example.jomajomadelivery.cart.entity.Cart;
+import com.example.jomajomadelivery.item.dto.response.ItemResponseDto;
 import com.example.jomajomadelivery.item.service.ItemService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestAttribute;
-import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @Controller
 @RequiredArgsConstructor
@@ -28,9 +29,9 @@ public class ItemController {
         return new ResponseEntity<>(HttpStatus.OK);
     }
 
-//    @GetMapping("/cartId")
-//    public ResponseEntity<List<ItemResponseDto>> findAllItem(@PathVariable Long cartId) {
-//        List<ItemResponseDto> itemList = itemService.findAllItem(cartId);
-//        return new ResponseEntity<>(itemList, HttpStatus.OK);
-//    }
+    @GetMapping("/{cartId}")
+    public ResponseEntity<List<ItemResponseDto>> findAllItem(@PathVariable Long cartId) {
+        List<ItemResponseDto> itemList = itemService.findAllItem(cartId);
+        return new ResponseEntity<>(itemList, HttpStatus.OK);
+    }
 }

--- a/src/main/java/com/example/jomajomadelivery/item/controller/ItemController.java
+++ b/src/main/java/com/example/jomajomadelivery/item/controller/ItemController.java
@@ -1,0 +1,36 @@
+package com.example.jomajomadelivery.item.controller;
+
+import com.example.jomajomadelivery.cart.dto.requestDto.AddCartRequestDto;
+import com.example.jomajomadelivery.cart.entity.Cart;
+import com.example.jomajomadelivery.item.service.ItemService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestAttribute;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+@Controller
+@RequiredArgsConstructor
+@RequestMapping("/items")
+public class ItemController {
+
+    private final ItemService itemService;
+
+    @PostMapping
+    public ResponseEntity<Void> addItem(
+            @RequestAttribute("dto") AddCartRequestDto dto,
+            @RequestAttribute("cart") Cart cart) {
+        System.out.println("item " + dto.menu_id());
+        System.out.println("item " + dto.quantity());
+        itemService.addItem(dto, cart);
+        return new ResponseEntity<>(HttpStatus.OK);
+    }
+
+//    @GetMapping("/cartId")
+//    public ResponseEntity<List<ItemResponseDto>> findAllItem(@PathVariable Long cartId) {
+//        List<ItemResponseDto> itemList = itemService.findAllItem(cartId);
+//        return new ResponseEntity<>(itemList, HttpStatus.OK);
+//    }
+}

--- a/src/main/java/com/example/jomajomadelivery/item/dto/response/ItemResponseDto.java
+++ b/src/main/java/com/example/jomajomadelivery/item/dto/response/ItemResponseDto.java
@@ -1,0 +1,28 @@
+package com.example.jomajomadelivery.item.dto.response;
+
+import com.example.jomajomadelivery.item.entity.Item;
+import lombok.Builder;
+
+@Builder
+public record ItemResponseDto(
+        Long itemId,
+        Long cartId,
+        Long menuId,
+        String name,
+        int quantity,
+        int price,
+        int totalPrice
+
+) {
+    public static ItemResponseDto toDto(Item item){
+        return ItemResponseDto.builder()
+                .itemId(item.getItemId())
+                .cartId(item.getCart().getCartId())
+                .menuId(item.getMenu().getMenu_id())
+                .name(item.getName())
+                .quantity(item.getQuantity())
+                .price(item.getPrice())
+                .totalPrice(item.getTotalPrice())
+                .build();
+    }
+}

--- a/src/main/java/com/example/jomajomadelivery/item/repository/ItmeRepositoy.java
+++ b/src/main/java/com/example/jomajomadelivery/item/repository/ItmeRepositoy.java
@@ -3,5 +3,8 @@ package com.example.jomajomadelivery.item.repository;
 import com.example.jomajomadelivery.item.entity.Item;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface ItmeRepositoy extends JpaRepository<Item,Long> {
+    List<Item> findAllByCart_CartId(Long cartId);
 }

--- a/src/main/java/com/example/jomajomadelivery/item/repository/ItmeRepositoy.java
+++ b/src/main/java/com/example/jomajomadelivery/item/repository/ItmeRepositoy.java
@@ -1,10 +1,11 @@
 package com.example.jomajomadelivery.item.repository;
 
+import com.example.jomajomadelivery.cart.entity.Cart;
 import com.example.jomajomadelivery.item.entity.Item;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
 
 public interface ItmeRepositoy extends JpaRepository<Item,Long> {
-    List<Item> findAllByCart_CartId(Long cartId);
+    List<Item> findAllByCart(Cart cart);
 }

--- a/src/main/java/com/example/jomajomadelivery/item/service/ItemService.java
+++ b/src/main/java/com/example/jomajomadelivery/item/service/ItemService.java
@@ -1,0 +1,33 @@
+package com.example.jomajomadelivery.item.service;
+
+import com.example.jomajomadelivery.cart.dto.requestDto.AddCartRequestDto;
+import com.example.jomajomadelivery.cart.entity.Cart;
+import com.example.jomajomadelivery.item.dto.response.ItemResponseDto;
+import com.example.jomajomadelivery.item.entity.Item;
+import com.example.jomajomadelivery.item.repository.ItmeRepositoy;
+import com.example.jomajomadelivery.menu.entity.Menu;
+import com.example.jomajomadelivery.menu.repository.MenuRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class ItemService {
+    private final ItmeRepositoy itmeRepositoy;
+    private final MenuRepository menuRepository;
+
+    public List<ItemResponseDto> findAllItem(Long cartId) {
+        itmeRepositoy.findAllByCart_CartId(cartId);
+        return null;
+    }
+
+    public void addItem(AddCartRequestDto dto, Cart cart) {
+        Menu menu = menuRepository.findById(dto.menu_id()).get();
+
+        Item item = Item.selectItme(cart, menu, dto.quantity());
+        itmeRepositoy.save(item);
+
+    }
+}

--- a/src/main/java/com/example/jomajomadelivery/item/service/ItemService.java
+++ b/src/main/java/com/example/jomajomadelivery/item/service/ItemService.java
@@ -19,8 +19,8 @@ public class ItemService {
     private final MenuRepository menuRepository;
 
     public List<ItemResponseDto> findAllItem(Long cartId) {
-        itmeRepositoy.findAllByCart_CartId(cartId);
-        return null;
+        List<Item> itemList = itmeRepositoy.findAllByCart_CartId(cartId);
+        return itemList.stream().map(ItemResponseDto::toDto).toList();
     }
 
     public void addItem(AddCartRequestDto dto, Cart cart) {

--- a/src/main/java/com/example/jomajomadelivery/item/service/ItemService.java
+++ b/src/main/java/com/example/jomajomadelivery/item/service/ItemService.java
@@ -2,11 +2,15 @@ package com.example.jomajomadelivery.item.service;
 
 import com.example.jomajomadelivery.cart.dto.requestDto.AddCartRequestDto;
 import com.example.jomajomadelivery.cart.entity.Cart;
+import com.example.jomajomadelivery.cart.entity.CartStatus;
+import com.example.jomajomadelivery.cart.repository.CartRepository;
 import com.example.jomajomadelivery.item.dto.response.ItemResponseDto;
 import com.example.jomajomadelivery.item.entity.Item;
 import com.example.jomajomadelivery.item.repository.ItmeRepositoy;
 import com.example.jomajomadelivery.menu.entity.Menu;
 import com.example.jomajomadelivery.menu.repository.MenuRepository;
+import com.example.jomajomadelivery.user.entity.User;
+import com.example.jomajomadelivery.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -16,18 +20,21 @@ import java.util.List;
 @RequiredArgsConstructor
 public class ItemService {
     private final ItmeRepositoy itmeRepositoy;
+    private final CartRepository cartRepository;
     private final MenuRepository menuRepository;
+    private final UserRepository userRepository;
 
-    public List<ItemResponseDto> findAllItem(Long cartId) {
-        List<Item> itemList = itmeRepositoy.findAllByCart_CartId(cartId);
-        return itemList.stream().map(ItemResponseDto::toDto).toList();
-    }
 
     public void addItem(AddCartRequestDto dto, Cart cart) {
         Menu menu = menuRepository.findById(dto.menu_id()).get();
-
         Item item = Item.selectItme(cart, menu, dto.quantity());
         itmeRepositoy.save(item);
+    }
 
+    public List<ItemResponseDto> findAllItem() {
+        User user = userRepository.findById(1L).get();
+        Cart cart = cartRepository.findCartByUserAndStatus(user,CartStatus.ORDERING).orElseThrow(()-> new RuntimeException());
+        List<Item> itemList = itmeRepositoy.findAllByCart(cart);
+        return itemList.stream().map(ItemResponseDto::toDto).toList();
     }
 }


### PR DESCRIPTION
## 🔘구현 기능
- 장바구니와 아이템을 분리하여
장바구니는 장바구니 생성~
아이템은 아이템생성~ 하여따

- 장바구니 조회는 처음에는 path어쩌구에서 카트id를 넘겼지만
수정 후 해당 유저의 사용중인 장바구니를 가져와 사용중인 장바구니의 아이템들을 출력하도록 수정하였다.(입력값x)

  <br/>

## 🔎 고민한 부분
cart컨트롤러에서 리다이렉트 하려고했지만 클라이언트에 url이 변경되어서
서버에서 서버로~ url변경 x되도록 forward를 했다. forward를하면 model도 잘 넘어가고 url도 안바뀐다.
item컨트롤러에서 @ModelAttribute를 하려고했지만 값이 안받아져서
@RequestAttribute("모델속성이름") Cart cart 해서 정상적으로 값을 받아올 수 있게 되었다.

  <br/>